### PR TITLE
Document interactive lesson templates in README

### DIFF
--- a/Presenter.html
+++ b/Presenter.html
@@ -737,6 +737,230 @@
             border-radius: var(--radius);
             margin-bottom: var(--space-6);
         }
+        .activity-feedback {
+            margin-top: var(--space-6);
+            background: color-mix(in srgb, var(--soft-white) 92%, white 8%);
+            border: 1px solid rgba(122, 132, 113, 0.16);
+            border-radius: var(--radius);
+            padding: clamp(20px, 3vw, 32px);
+            display: grid;
+            gap: var(--space-4);
+        }
+        .activity-feedback__summary {
+            margin: 0;
+            font-weight: 700;
+            color: var(--forest-shadow);
+        }
+        .activity-feedback__list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: var(--space-4);
+        }
+        .activity-feedback__item {
+            border-left: 4px solid color-mix(in srgb, var(--secondary-sage) 70%, var(--primary-sage) 30%);
+            padding-left: var(--space-4);
+        }
+        .activity-feedback__item strong { color: var(--forest-shadow); }
+        .activity-feedback__item p { margin: 0; }
+        .activity-feedback__item p + p { margin-top: var(--space-2); }
+        .activity-feedback__item.is-incorrect { border-left-color: #C76B5E; }
+        .activity-feedback__item.is-correct { border-left-color: var(--secondary-sage); }
+
+        /* Gap-fill activity */
+        .gapfill-activity {
+            display: grid;
+            gap: var(--space-5);
+        }
+        .gapfill-paragraph {
+            background: color-mix(in srgb, var(--warm-cream) 85%, white 15%);
+            border: 1px solid rgba(122, 132, 113, 0.18);
+            border-radius: var(--radius);
+            padding: clamp(20px, 3vw, 32px);
+            font-size: var(--step-1);
+            line-height: 1.8;
+        }
+        .gapfill-gap {
+            display: inline-flex;
+            align-items: center;
+            margin: 0 var(--space-1);
+            border-radius: 10px;
+            padding: 0 var(--space-1);
+        }
+        .gapfill-gap select {
+            min-width: 140px;
+            padding: 10px 16px;
+            border-radius: 10px;
+            border: 2px solid var(--tertiary-sage);
+            background: #fff;
+            font-weight: 600;
+            color: var(--primary-sage);
+            cursor: pointer;
+            transition: border-color var(--dur-2) var(--ease-ambient), box-shadow var(--dur-2) var(--ease-ambient);
+        }
+        .gapfill-gap select:focus-visible {
+            border-color: var(--secondary-sage);
+            box-shadow: var(--ring);
+            outline: none;
+        }
+        .gapfill-gap.is-correct select {
+            border-color: color-mix(in srgb, var(--secondary-sage) 80%, var(--primary-sage) 20%);
+            background: color-mix(in srgb, var(--soft-white) 85%, var(--secondary-sage) 15%);
+        }
+        .gapfill-gap.is-incorrect select {
+            border-color: #C76B5E;
+            background: color-mix(in srgb, #fff 85%, #F7D8D6 15%);
+        }
+
+        /* Ranking activity */
+        .ranking-activity {
+            display: grid;
+            gap: var(--space-5);
+        }
+        .ranking-intro { margin: 0; font-size: var(--step-0); color: var(--ink-muted); }
+        .ranking-list {
+            list-style: none;
+            counter-reset: ranking-counter;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: var(--space-4);
+        }
+        .ranking-item {
+            counter-increment: ranking-counter;
+            position: relative;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--space-4);
+            padding: var(--space-4);
+            padding-left: clamp(56px, 6vw, 72px);
+            border: 1px solid rgba(122, 132, 113, 0.18);
+            border-radius: var(--radius);
+            background: color-mix(in srgb, var(--soft-white) 92%, white 8%);
+            box-shadow: var(--shadow-1);
+        }
+        .ranking-item::before {
+            content: counter(ranking-counter);
+            position: absolute;
+            left: clamp(16px, 2vw, 24px);
+            top: 50%;
+            transform: translateY(-50%);
+            width: 36px;
+            height: 36px;
+            border-radius: 999px;
+            background: color-mix(in srgb, var(--secondary-sage) 85%, var(--primary-sage) 15%);
+            color: var(--soft-white);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 800;
+        }
+        .ranking-item.is-correct {
+            border-color: color-mix(in srgb, var(--secondary-sage) 80%, var(--primary-sage) 20%);
+            background: color-mix(in srgb, var(--soft-white) 85%, var(--secondary-sage) 15%);
+        }
+        .ranking-item.is-incorrect {
+            border-color: #C76B5E;
+            background: color-mix(in srgb, #fff 85%, #F7D8D6 15%);
+        }
+        .ranking-label { font-weight: 700; font-size: var(--step-0); color: var(--forest-shadow); }
+        .ranking-controls { display: inline-flex; gap: var(--space-2); }
+        .ranking-controls button {
+            min-height: var(--target-min);
+            padding: 8px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--tertiary-sage);
+            background: #fff;
+            color: var(--primary-sage);
+            cursor: pointer;
+            font-weight: 600;
+            transition: background var(--dur-2) var(--ease-ambient), border-color var(--dur-2) var(--ease-ambient), transform var(--dur-1) var(--ease-ambient);
+        }
+        .ranking-controls button:hover { background: var(--hover-sage); }
+        .ranking-controls button:focus-visible { outline: none; box-shadow: var(--ring); }
+
+        /* Grouping activity */
+        .grouping-activity {
+            display: grid;
+            gap: var(--space-5);
+        }
+        .grouping-grid {
+            display: grid;
+            gap: var(--space-4);
+        }
+        @media (min-width: 720px) {
+            .grouping-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        }
+        .grouping-item {
+            display: grid;
+            gap: var(--space-2);
+            border: 1px solid rgba(122, 132, 113, 0.18);
+            border-radius: var(--radius);
+            background: color-mix(in srgb, var(--soft-white) 94%, white 6%);
+            padding: var(--space-4);
+        }
+        .grouping-item strong { font-size: var(--step-0); }
+        .grouping-item.is-correct { border-color: color-mix(in srgb, var(--secondary-sage) 80%, var(--primary-sage) 20%); background: color-mix(in srgb, var(--soft-white) 85%, var(--secondary-sage) 15%); }
+        .grouping-item.is-incorrect { border-color: #C76B5E; background: color-mix(in srgb, #fff 85%, #F7D8D6 15%); }
+
+        /* Matching grid activity */
+        .matching-activity { display: grid; gap: var(--space-5); }
+        .matching-table-wrapper { overflow-x: auto; }
+        .matching-table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 520px;
+        }
+        .matching-table th,
+        .matching-table td {
+            padding: var(--space-3);
+            border-bottom: 1px solid rgba(122, 132, 113, 0.16);
+            text-align: center;
+        }
+        .matching-table thead th {
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+            font-size: 0.85rem;
+            color: var(--ink-muted);
+        }
+        .matching-table tbody th {
+            text-align: left;
+            color: var(--forest-shadow);
+            font-weight: 700;
+        }
+        .matching-table tbody tr.is-correct { background: color-mix(in srgb, var(--soft-white) 85%, var(--secondary-sage) 15%); }
+        .matching-table tbody tr.is-incorrect { background: color-mix(in srgb, #fff 85%, #F7D8D6 15%); }
+        .matching-radio { display: inline-flex; align-items: center; justify-content: center; cursor: pointer; width: 28px; height: 28px; }
+        .matching-radio input { display: none; }
+        .matching-radio-indicator {
+            width: 18px;
+            height: 18px;
+            border-radius: 999px;
+            border: 2px solid var(--tertiary-sage);
+            transition: border-color var(--dur-2) var(--ease-ambient), transform var(--dur-1) var(--ease-ambient);
+            position: relative;
+        }
+        .matching-radio:hover .matching-radio-indicator { border-color: var(--primary-sage); }
+        .matching-radio input:checked + .matching-radio-indicator {
+            border-color: var(--primary-sage);
+        }
+        .matching-radio-indicator::after {
+            content: "";
+            position: absolute;
+            inset: 4px;
+            border-radius: inherit;
+            background: var(--primary-sage);
+            transform: scale(0);
+            transition: transform var(--dur-2) var(--ease-ambient);
+        }
+        .matching-radio input:checked + .matching-radio-indicator::after { transform: scale(1); }
+
+        @media (max-width: 767px) {
+            .ranking-item { flex-direction: column; align-items: flex-start; }
+            .ranking-controls { justify-content: flex-start; }
+        }
         .slide-list {
             list-style: none;
             padding-left: 0;
@@ -1710,6 +1934,220 @@
                             { id: "elt-followup", label: "Follow-up idea", placeholder: "Capture homework, extension, or differentiation options." }
                         ],
                         nav: { nextAction: "restart", nextLabel: "Finish & Restart", nextIcon: "fas fa-check" }
+                    }
+                ]
+            },
+            questionTypesShowcase: {
+                id: "question-types-showcase",
+                label: "Interactive question types",
+                meta: {
+                    eyebrow: "Mosaic Presenter",
+                    descriptor: "Interactive templates converted from standalone activities.",
+                    pageTitle: "Interactive Question Types – Instructional Slides"
+                },
+                sections: [
+                    { title: "Gap-fill dropdown", slideKeys: ["roman-gapfill"] },
+                    { title: "Ordering task", slideKeys: ["writing-process-ranking"] },
+                    { title: "Categorising language", slideKeys: ["discourse-grouping"] },
+                    { title: "Multiple-choice grid", slideKeys: ["states-of-matter-grid"] }
+                ],
+                slides: [
+                    {
+                        key: "roman-gapfill",
+                        type: "gapfill",
+                        icon: "fas fa-landmark",
+                        title: "The Roman Empire",
+                        subtitle: "Fill in the gaps to complete each sentence.",
+                        image: {
+                            src: "https://images.pexels.com/photos/208636/pexels-photo-208636.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+                            alt: "Exterior of the Roman Colosseum at sunset"
+                        },
+                        instructions: "Select the best answer in each dropdown before checking your work.",
+                        paragraph: [
+                            { type: "text", content: "The famous amphitheater in the center of the city, known for its gladiator contests, is called the " },
+                            {
+                                type: "gap",
+                                id: "roman-gap-1",
+                                answer: "Colosseum",
+                                options: ["Colosseum", "Pantheon", "Forum"],
+                                feedbackTitle: "The famous amphitheater is the Colosseum",
+                                explanation: "The Colosseum was the largest amphitheater ever built and was used for gladiatorial contests and public spectacles."
+                            },
+                            { type: "text", content: ". The governing and advisory assembly of the aristocracy in the ancient Roman Republic was the " },
+                            {
+                                type: "gap",
+                                id: "roman-gap-2",
+                                answer: "Senate",
+                                options: ["Assembly", "Senate", "Council"],
+                                feedbackTitle: "The governing assembly was the Senate",
+                                explanation: "The Senate was a permanent and powerful institution in the Roman government, composed of the most prominent men in Rome."
+                            },
+                            { type: "text", content: ". A " },
+                            {
+                                type: "gap",
+                                id: "roman-gap-3",
+                                answer: "legion",
+                                options: ["battalion", "phalanx", "legion"],
+                                feedbackTitle: "The largest Roman army unit was the legion",
+                                explanation: "The legion was the backbone of the Roman military machine, known for its discipline and effectiveness in battle."
+                            },
+                            { type: "text", content: " was the largest unit of the Roman army. According to legend, the city of " },
+                            {
+                                type: "gap",
+                                id: "roman-gap-4",
+                                answer: "Rome",
+                                options: ["Athens", "Carthage", "Rome"],
+                                feedbackTitle: "The city founded by twins was Rome",
+                                explanation: "The founding myth of Rome, involving twin brothers Romulus and Remus, is a cornerstone of Roman culture and history."
+                            },
+                            { type: "text", content: " was founded by the twin brothers Romulus and Remus in 753 BC." }
+                        ]
+                    },
+                    {
+                        key: "writing-process-ranking",
+                        type: "ranking",
+                        icon: "fas fa-list-ol",
+                        title: "The Writing Process",
+                        subtitle: "Arrange the stages from first to last.",
+                        image: {
+                            src: "https://images.pexels.com/photos/670723/pexels-photo-670723.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+                            alt: "Writer planning ideas with a notebook and laptop"
+                        },
+                        instructions: "Move the stages until they are in the correct order, then check your work.",
+                        items: [
+                            {
+                                id: "prewriting",
+                                label: "Prewriting",
+                                correctRank: 1,
+                                explanation: "Prewriting is the first step, where you brainstorm ideas, research, and outline your topic before you begin writing."
+                            },
+                            {
+                                id: "drafting",
+                                label: "Drafting",
+                                correctRank: 2,
+                                explanation: "Drafting is the second stage. This is where you write the first version of your text, focusing on getting your ideas down on paper."
+                            },
+                            {
+                                id: "revising",
+                                label: "Revising",
+                                correctRank: 3,
+                                explanation: "Revising is the third stage. Here, you review the content, organization, and clarity of your draft, making significant changes to improve the overall piece."
+                            },
+                            {
+                                id: "editing",
+                                label: "Editing & Proofreading",
+                                correctRank: 4,
+                                explanation: "Editing & Proofreading is the fourth stage. After revising the big picture, you focus on correcting grammar, spelling, punctuation, and formatting errors."
+                            },
+                            {
+                                id: "publishing",
+                                label: "Publishing",
+                                correctRank: 5,
+                                explanation: "Publishing is the final stage, where you share your polished work with its intended audience."
+                            }
+                        ],
+                        initialOrder: ["revising", "prewriting", "publishing", "drafting", "editing"],
+                        checkLabel: "Check order",
+                        resetLabel: "Reset order"
+                    },
+                    {
+                        key: "discourse-grouping",
+                        type: "grouping",
+                        icon: "fas fa-language",
+                        title: "Discourse Markers",
+                        subtitle: "Categorise these linking words by their function.",
+                        image: {
+                            src: "https://images.pexels.com/photos/159775/books-college-library-learning-159775.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+                            alt: "Stacks of books on a library table"
+                        },
+                        instructions: "Assign each linking word to the function it best represents.",
+                        categories: [
+                            { id: "addition", label: "Addition" },
+                            { id: "contrast", label: "Contrast" },
+                            { id: "consequence", label: "Consequence" }
+                        ],
+                        items: [
+                            {
+                                id: "however",
+                                label: "However",
+                                category: "contrast",
+                                explanation: "'However' is used to introduce a statement that contrasts with or seems to contradict something that has been said previously."
+                            },
+                            {
+                                id: "furthermore",
+                                label: "Furthermore",
+                                category: "addition",
+                                explanation: "'Furthermore' adds another piece of information to the point you are making."
+                            },
+                            {
+                                id: "therefore",
+                                label: "Therefore",
+                                category: "consequence",
+                                explanation: "'Therefore' indicates that a statement is the logical consequence of the one that came before it."
+                            },
+                            {
+                                id: "on-the-other-hand",
+                                label: "On the other hand",
+                                category: "contrast",
+                                explanation: "'On the other hand' is used to present a contrasting point of view."
+                            },
+                            {
+                                id: "as-a-result",
+                                label: "As a result",
+                                category: "consequence",
+                                explanation: "'As a result' shows that the second statement is a result of the first."
+                            },
+                            {
+                                id: "moreover",
+                                label: "Moreover",
+                                category: "addition",
+                                explanation: "'Moreover' is used to introduce a piece of information that adds to or supports the previous one."
+                            }
+                        ]
+                    },
+                    {
+                        key: "states-of-matter-grid",
+                        type: "matching",
+                        icon: "fas fa-table",
+                        title: "States of Matter",
+                        subtitle: "Match each state to its defining properties.",
+                        image: {
+                            src: "https://images.pexels.com/photos/590570/pexels-photo-590570.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+                            alt: "Scientist working with a glowing plasma ball"
+                        },
+                        instructions: "For each state of matter, choose the property that best fits before checking your answers.",
+                        columns: [
+                            { id: "col-1", label: "Definite Shape & Volume" },
+                            { id: "col-2", label: "Definite Volume" },
+                            { id: "col-3", label: "Indefinite Shape & Volume" },
+                            { id: "col-4", label: "Ionized Gas" }
+                        ],
+                        rows: [
+                            {
+                                id: "solid",
+                                label: "Solid",
+                                correctColumn: "col-1",
+                                explanation: "A solid's particles are tightly packed in a fixed structure, giving it a definite shape and volume."
+                            },
+                            {
+                                id: "liquid",
+                                label: "Liquid",
+                                correctColumn: "col-2",
+                                explanation: "A liquid's particles can slide past one another, allowing it to take the shape of its container, but its volume remains constant."
+                            },
+                            {
+                                id: "gas",
+                                label: "Gas",
+                                correctColumn: "col-3",
+                                explanation: "A gas's particles are far apart and move randomly, allowing it to expand to fill any container, giving it an indefinite shape and volume."
+                            },
+                            {
+                                id: "plasma",
+                                label: "Plasma",
+                                correctColumn: "col-4",
+                                explanation: "Plasma is a superheated state of matter where atoms are stripped of their electrons, creating an ionized gas."
+                            }
+                        ]
                     }
                 ]
             }
@@ -2752,6 +3190,71 @@
             return list;
         }
 
+        function createActivityControls({ onCheck, onReset, checkLabel = "Check answers", resetLabel = "Reset" } = {}) {
+            const wrapper = document.createElement("div");
+            wrapper.className = "activity-controls animate-on-scroll";
+
+            let checkButton = null;
+            if (typeof onCheck === "function") {
+                checkButton = document.createElement("button");
+                checkButton.type = "button";
+                checkButton.className = "activity-btn";
+                checkButton.textContent = checkLabel;
+                checkButton.addEventListener("click", onCheck);
+                wrapper.appendChild(checkButton);
+            }
+
+            let resetButton = null;
+            if (typeof onReset === "function") {
+                resetButton = document.createElement("button");
+                resetButton.type = "button";
+                resetButton.className = "activity-btn secondary";
+                resetButton.textContent = resetLabel;
+                resetButton.addEventListener("click", onReset);
+                wrapper.appendChild(resetButton);
+            }
+
+            return { wrapper, checkButton, resetButton };
+        }
+
+        function createActivityFeedback(initialSummary = "Check your work to see detailed feedback.") {
+            const wrapper = document.createElement("div");
+            wrapper.className = "activity-feedback animate-on-scroll";
+
+            const summary = document.createElement("p");
+            summary.className = "activity-feedback__summary";
+            summary.textContent = initialSummary;
+
+            const list = document.createElement("ul");
+            list.className = "activity-feedback__list";
+
+            wrapper.appendChild(summary);
+            wrapper.appendChild(list);
+
+            return { wrapper, summary, list };
+        }
+
+        function formatOrdinal(value) {
+            const number = Number(value);
+            if (!Number.isFinite(number)) {
+                return String(value);
+            }
+            const absValue = Math.abs(number);
+            const suffix = absValue % 100 >= 11 && absValue % 100 <= 13
+                ? "th"
+                : { 1: "st", 2: "nd", 3: "rd" }[absValue % 10] || "th";
+            return `${number}${suffix}`;
+        }
+
+        function shuffleArray(sourceArray = []) {
+            const array = Array.from(sourceArray);
+            for (let i = array.length - 1; i > 0; i -= 1) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [array[i], array[j]] = [array[j], array[i]];
+            }
+            return array;
+        }
+
         function renderHeroSlide(slideElement, config) {
             if (config.image) {
                 const wrapper = document.createElement("div");
@@ -2805,6 +3308,655 @@
             if (list) {
                 content.appendChild(list);
             }
+            slideElement.appendChild(content);
+        }
+
+        function renderGapfillSlide(slideElement, config) {
+            if (config.title) {
+                const headingWrapper = document.createElement("div");
+                headingWrapper.className = "animate-on-scroll";
+                headingWrapper.appendChild(createIconHeading(config.icon, config.title));
+                slideElement.appendChild(headingWrapper);
+            }
+            if (config.subtitle) {
+                const rubricWrapper = document.createElement("div");
+                rubricWrapper.className = "animate-on-scroll";
+                rubricWrapper.appendChild(createRubric(config.subtitle));
+                slideElement.appendChild(rubricWrapper);
+            }
+
+            const content = document.createElement("div");
+            content.className = "slide-content gapfill-activity";
+
+            if (config.image) {
+                const img = createImageElement(config.image);
+                if (img) {
+                    img.classList.add("animate-on-scroll");
+                    content.appendChild(img);
+                }
+            }
+
+            if (config.instructions) {
+                content.appendChild(createParagraph(config.instructions));
+            }
+
+            const paragraph = document.createElement("p");
+            paragraph.className = "gapfill-paragraph animate-on-scroll";
+            const segments = Array.isArray(config.paragraph) ? config.paragraph : [];
+            const gaps = [];
+            segments.forEach((segment, index) => {
+                if (typeof segment === "string") {
+                    paragraph.appendChild(document.createTextNode(segment));
+                } else if (segment && segment.type === "text") {
+                    paragraph.appendChild(document.createTextNode(segment.content || ""));
+                } else if (segment && segment.type === "gap") {
+                    const wrapper = document.createElement("span");
+                    wrapper.className = "gapfill-gap";
+                    const select = document.createElement("select");
+                    const placeholder = document.createElement("option");
+                    placeholder.value = "";
+                    placeholder.textContent = segment.placeholder || "Select an option";
+                    select.appendChild(placeholder);
+                    (segment.options || []).forEach((option) => {
+                        const optionElement = document.createElement("option");
+                        if (typeof option === "string") {
+                            optionElement.value = option;
+                            optionElement.textContent = option;
+                        } else if (option && typeof option === "object") {
+                            optionElement.value = option.value;
+                            optionElement.textContent = option.label || option.value;
+                        }
+                        select.appendChild(optionElement);
+                    });
+                    wrapper.appendChild(select);
+                    paragraph.appendChild(wrapper);
+                    gaps.push({
+                        wrapper,
+                        select,
+                        data: {
+                            id: segment.id || `${config.key || "gapfill"}-gap-${index + 1}`,
+                            answer: segment.answer,
+                            feedbackTitle: segment.feedbackTitle || segment.label,
+                            explanation: segment.explanation
+                        }
+                    });
+                }
+            });
+            content.appendChild(paragraph);
+
+            const initialSummary = config.feedbackSummary || "Check your work to see detailed feedback.";
+            const feedback = createActivityFeedback(initialSummary);
+
+            const evaluate = () => {
+                let attempted = 0;
+                let correct = 0;
+                feedback.list.innerHTML = "";
+                gaps.forEach((gap) => {
+                    const { wrapper, select, data } = gap;
+                    wrapper.classList.remove("is-correct", "is-incorrect");
+                    const value = select.value;
+                    if (!value) {
+                        return;
+                    }
+                    attempted += 1;
+                    const isCorrect = value === data.answer;
+                    if (isCorrect) {
+                        correct += 1;
+                    }
+                    wrapper.classList.add(isCorrect ? "is-correct" : "is-incorrect");
+                    const selectedLabel = select.options[select.selectedIndex]?.textContent || value;
+
+                    const item = document.createElement("li");
+                    item.className = `activity-feedback__item ${isCorrect ? "is-correct" : "is-incorrect"}`;
+
+                    const title = document.createElement("p");
+                    const strong = document.createElement("strong");
+                    strong.textContent = data.feedbackTitle || `Blank ${data.id}`;
+                    title.appendChild(strong);
+                    item.appendChild(title);
+
+                    const yourAnswer = document.createElement("p");
+                    yourAnswer.innerHTML = `<strong>Your answer:</strong> ${selectedLabel}`;
+                    item.appendChild(yourAnswer);
+
+                    if (!isCorrect) {
+                        const correctAnswer = document.createElement("p");
+                        correctAnswer.innerHTML = `<strong>Correct answer:</strong> ${data.answer}`;
+                        item.appendChild(correctAnswer);
+                    }
+
+                    if (data.explanation) {
+                        const explanation = document.createElement("p");
+                        explanation.textContent = data.explanation;
+                        item.appendChild(explanation);
+                    }
+
+                    feedback.list.appendChild(item);
+                });
+
+                feedback.summary.textContent = attempted
+                    ? `You answered ${correct} of ${attempted} correctly.`
+                    : "Choose an answer for at least one blank to see feedback.";
+            };
+
+            const reset = () => {
+                gaps.forEach((gap) => {
+                    gap.wrapper.classList.remove("is-correct", "is-incorrect");
+                    gap.select.value = "";
+                });
+                feedback.list.innerHTML = "";
+                feedback.summary.textContent = initialSummary;
+            };
+
+            const controls = createActivityControls({
+                onCheck: evaluate,
+                onReset: reset,
+                checkLabel: config.checkLabel || "Check answers",
+                resetLabel: config.resetLabel || "Reset"
+            });
+
+            content.appendChild(controls.wrapper);
+            content.appendChild(feedback.wrapper);
+
+            slideElement.appendChild(content);
+        }
+
+        function renderRankingSlide(slideElement, config) {
+            if (config.title) {
+                const headingWrapper = document.createElement("div");
+                headingWrapper.className = "animate-on-scroll";
+                headingWrapper.appendChild(createIconHeading(config.icon, config.title));
+                slideElement.appendChild(headingWrapper);
+            }
+            if (config.subtitle) {
+                const rubricWrapper = document.createElement("div");
+                rubricWrapper.className = "animate-on-scroll";
+                rubricWrapper.appendChild(createRubric(config.subtitle));
+                slideElement.appendChild(rubricWrapper);
+            }
+
+            const content = document.createElement("div");
+            content.className = "slide-content ranking-activity";
+
+            if (config.image) {
+                const img = createImageElement(config.image);
+                if (img) {
+                    img.classList.add("animate-on-scroll");
+                    content.appendChild(img);
+                }
+            }
+
+            if (config.instructions) {
+                const intro = document.createElement("p");
+                intro.className = "ranking-intro animate-on-scroll";
+                intro.textContent = config.instructions;
+                content.appendChild(intro);
+            }
+
+            const list = document.createElement("ol");
+            list.className = "ranking-list";
+
+            const items = Array.isArray(config.items) ? config.items : [];
+            const itemMap = new Map();
+            items.forEach((item) => {
+                if (item && item.id) {
+                    itemMap.set(item.id, item);
+                }
+            });
+            const correctOrder = items
+                .slice()
+                .sort((a, b) => (a.correctRank ?? 0) - (b.correctRank ?? 0))
+                .map((item) => item.id);
+            const initialOrder = Array.isArray(config.initialOrder) && config.initialOrder.length === correctOrder.length
+                ? config.initialOrder.filter((id) => itemMap.has(id))
+                : shuffleArray(correctOrder);
+            const resolvedOrder = initialOrder.length === correctOrder.length ? initialOrder : correctOrder;
+
+            const createListItem = (item) => {
+                const li = document.createElement("li");
+                li.className = "ranking-item animate-on-scroll";
+                li.dataset.itemId = item.id;
+
+                const label = document.createElement("span");
+                label.className = "ranking-label";
+                label.textContent = item.label;
+                li.appendChild(label);
+
+                const controls = document.createElement("div");
+                controls.className = "ranking-controls";
+
+                const moveUp = document.createElement("button");
+                moveUp.type = "button";
+                moveUp.textContent = "Move up";
+                moveUp.setAttribute("aria-label", `Move ${item.label} up`);
+                moveUp.addEventListener("click", () => {
+                    const previous = li.previousElementSibling;
+                    if (previous) {
+                        list.insertBefore(li, previous);
+                    }
+                });
+
+                const moveDown = document.createElement("button");
+                moveDown.type = "button";
+                moveDown.textContent = "Move down";
+                moveDown.setAttribute("aria-label", `Move ${item.label} down`);
+                moveDown.addEventListener("click", () => {
+                    const next = li.nextElementSibling?.nextElementSibling;
+                    if (next) {
+                        list.insertBefore(li, next);
+                    } else {
+                        list.appendChild(li);
+                    }
+                });
+
+                controls.appendChild(moveUp);
+                controls.appendChild(moveDown);
+                li.appendChild(controls);
+                return li;
+            };
+
+            resolvedOrder.forEach((id) => {
+                const item = itemMap.get(id);
+                if (item) {
+                    list.appendChild(createListItem(item));
+                }
+            });
+
+            const baselineOrder = Array.from(list.children).map((child) => child.dataset.itemId);
+            content.appendChild(list);
+
+            const initialSummary = config.feedbackSummary || "Check your work to see detailed feedback.";
+            const feedback = createActivityFeedback(initialSummary);
+
+            const evaluate = () => {
+                const itemsInDom = Array.from(list.children);
+                let correct = 0;
+                feedback.list.innerHTML = "";
+                itemsInDom.forEach((element, index) => {
+                    const itemId = element.dataset.itemId;
+                    const item = itemMap.get(itemId);
+                    if (!item) {
+                        return;
+                    }
+                    element.classList.remove("is-correct", "is-incorrect");
+                    const expectedId = correctOrder[index];
+                    const isCorrect = expectedId === itemId;
+                    if (isCorrect) {
+                        correct += 1;
+                    }
+                    element.classList.add(isCorrect ? "is-correct" : "is-incorrect");
+
+                    const detail = document.createElement("li");
+                    detail.className = `activity-feedback__item ${isCorrect ? "is-correct" : "is-incorrect"}`;
+
+                    const heading = document.createElement("p");
+                    const strong = document.createElement("strong");
+                    strong.textContent = item.label;
+                    heading.appendChild(strong);
+                    detail.appendChild(heading);
+
+                    const yourAnswer = document.createElement("p");
+                    yourAnswer.innerHTML = `<strong>Your order:</strong> ${formatOrdinal(index + 1)}`;
+                    detail.appendChild(yourAnswer);
+
+                    if (!isCorrect) {
+                        const correctAnswer = document.createElement("p");
+                        const targetPosition = item.correctRank ?? (correctOrder.indexOf(itemId) + 1);
+                        correctAnswer.innerHTML = `<strong>Correct order:</strong> ${formatOrdinal(targetPosition)}`;
+                        detail.appendChild(correctAnswer);
+                    }
+
+                    if (item.explanation) {
+                        const explanation = document.createElement("p");
+                        explanation.textContent = item.explanation;
+                        detail.appendChild(explanation);
+                    }
+
+                    feedback.list.appendChild(detail);
+                });
+
+                const attempted = itemsInDom.length;
+                feedback.summary.textContent = attempted
+                    ? `You placed ${correct} of ${attempted} stages correctly.`
+                    : "Reorder the stages to check your understanding.";
+            };
+
+            const reset = () => {
+                baselineOrder.forEach((itemId) => {
+                    const element = Array.from(list.children).find((child) => child.dataset.itemId === itemId);
+                    if (element) {
+                        element.classList.remove("is-correct", "is-incorrect");
+                        list.appendChild(element);
+                    }
+                });
+                feedback.list.innerHTML = "";
+                feedback.summary.textContent = initialSummary;
+            };
+
+            const controls = createActivityControls({
+                onCheck: evaluate,
+                onReset: reset,
+                checkLabel: config.checkLabel || "Check order",
+                resetLabel: config.resetLabel || "Reset order"
+            });
+
+            content.appendChild(controls.wrapper);
+            content.appendChild(feedback.wrapper);
+
+            slideElement.appendChild(content);
+        }
+
+        function renderGroupingSlide(slideElement, config) {
+            if (config.title) {
+                const headingWrapper = document.createElement("div");
+                headingWrapper.className = "animate-on-scroll";
+                headingWrapper.appendChild(createIconHeading(config.icon, config.title));
+                slideElement.appendChild(headingWrapper);
+            }
+            if (config.subtitle) {
+                const rubricWrapper = document.createElement("div");
+                rubricWrapper.className = "animate-on-scroll";
+                rubricWrapper.appendChild(createRubric(config.subtitle));
+                slideElement.appendChild(rubricWrapper);
+            }
+
+            const content = document.createElement("div");
+            content.className = "slide-content grouping-activity";
+
+            if (config.image) {
+                const img = createImageElement(config.image);
+                if (img) {
+                    img.classList.add("animate-on-scroll");
+                    content.appendChild(img);
+                }
+            }
+
+            if (config.instructions) {
+                content.appendChild(createParagraph(config.instructions));
+            }
+
+            const grid = document.createElement("div");
+            grid.className = "grouping-grid";
+
+            const categories = Array.isArray(config.categories) ? config.categories : [];
+            const categoryMap = new Map();
+            categories.forEach((category) => {
+                if (category && category.id) {
+                    categoryMap.set(category.id, category.label || category.id);
+                }
+            });
+
+            const items = Array.isArray(config.items) ? config.items : [];
+            const itemEntries = [];
+            items.forEach((item, index) => {
+                if (!item || !item.id) {
+                    return;
+                }
+                const wrapper = document.createElement("div");
+                wrapper.className = "grouping-item animate-on-scroll";
+
+                const label = document.createElement("strong");
+                label.textContent = item.label;
+                wrapper.appendChild(label);
+
+                const select = document.createElement("select");
+                select.id = `${slideElement.id}-grouping-${index + 1}`;
+                const placeholder = document.createElement("option");
+                placeholder.value = "";
+                placeholder.textContent = config.placeholder || "Choose a category";
+                select.appendChild(placeholder);
+                categories.forEach((category) => {
+                    const option = document.createElement("option");
+                    option.value = category.id;
+                    option.textContent = category.label;
+                    select.appendChild(option);
+                });
+                wrapper.appendChild(select);
+                grid.appendChild(wrapper);
+                itemEntries.push({ wrapper, select, item });
+            });
+
+            content.appendChild(grid);
+
+            const initialSummary = config.feedbackSummary || "Check your work to see detailed feedback.";
+            const feedback = createActivityFeedback(initialSummary);
+
+            const evaluate = () => {
+                let attempted = 0;
+                let correct = 0;
+                feedback.list.innerHTML = "";
+                itemEntries.forEach(({ wrapper, select, item }) => {
+                    wrapper.classList.remove("is-correct", "is-incorrect");
+                    const value = select.value;
+                    if (!value) {
+                        return;
+                    }
+                    attempted += 1;
+                    const isCorrect = value === item.category;
+                    if (isCorrect) {
+                        correct += 1;
+                    }
+                    wrapper.classList.add(isCorrect ? "is-correct" : "is-incorrect");
+
+                    const detail = document.createElement("li");
+                    detail.className = `activity-feedback__item ${isCorrect ? "is-correct" : "is-incorrect"}`;
+
+                    const heading = document.createElement("p");
+                    const strong = document.createElement("strong");
+                    strong.textContent = item.label;
+                    heading.appendChild(strong);
+                    detail.appendChild(heading);
+
+                    const yourAnswer = document.createElement("p");
+                    yourAnswer.innerHTML = `<strong>Your category:</strong> ${categoryMap.get(value) || value}`;
+                    detail.appendChild(yourAnswer);
+
+                    if (!isCorrect) {
+                        const correctAnswer = document.createElement("p");
+                        correctAnswer.innerHTML = `<strong>Correct category:</strong> ${categoryMap.get(item.category) || item.category}`;
+                        detail.appendChild(correctAnswer);
+                    }
+
+                    if (item.explanation) {
+                        const explanation = document.createElement("p");
+                        explanation.textContent = item.explanation;
+                        detail.appendChild(explanation);
+                    }
+
+                    feedback.list.appendChild(detail);
+                });
+
+                feedback.summary.textContent = attempted
+                    ? `You sorted ${correct} of ${attempted} items correctly.`
+                    : "Choose a category for at least one item to see feedback.";
+            };
+
+            const reset = () => {
+                itemEntries.forEach(({ wrapper, select }) => {
+                    wrapper.classList.remove("is-correct", "is-incorrect");
+                    select.value = "";
+                });
+                feedback.list.innerHTML = "";
+                feedback.summary.textContent = initialSummary;
+            };
+
+            const controls = createActivityControls({
+                onCheck: evaluate,
+                onReset: reset,
+                checkLabel: config.checkLabel || "Check categories",
+                resetLabel: config.resetLabel || "Reset"
+            });
+
+            content.appendChild(controls.wrapper);
+            content.appendChild(feedback.wrapper);
+
+            slideElement.appendChild(content);
+        }
+
+        function renderMatchingSlide(slideElement, config) {
+            if (config.title) {
+                const headingWrapper = document.createElement("div");
+                headingWrapper.className = "animate-on-scroll";
+                headingWrapper.appendChild(createIconHeading(config.icon, config.title));
+                slideElement.appendChild(headingWrapper);
+            }
+            if (config.subtitle) {
+                const rubricWrapper = document.createElement("div");
+                rubricWrapper.className = "animate-on-scroll";
+                rubricWrapper.appendChild(createRubric(config.subtitle));
+                slideElement.appendChild(rubricWrapper);
+            }
+
+            const content = document.createElement("div");
+            content.className = "slide-content matching-activity";
+
+            if (config.image) {
+                const img = createImageElement(config.image);
+                if (img) {
+                    img.classList.add("animate-on-scroll");
+                    content.appendChild(img);
+                }
+            }
+
+            if (config.instructions) {
+                content.appendChild(createParagraph(config.instructions));
+            }
+
+            const tableWrapper = document.createElement("div");
+            tableWrapper.className = "matching-table-wrapper";
+            const table = document.createElement("table");
+            table.className = "matching-table animate-on-scroll";
+
+            const columns = Array.isArray(config.columns) ? config.columns : [];
+            const rows = Array.isArray(config.rows) ? config.rows : [];
+            const columnMap = new Map(columns.map((column) => [column.id, column.label]));
+
+            const thead = document.createElement("thead");
+            const headerRow = document.createElement("tr");
+            const blankHeader = document.createElement("th");
+            blankHeader.scope = "col";
+            blankHeader.textContent = "";
+            headerRow.appendChild(blankHeader);
+            columns.forEach((column) => {
+                const th = document.createElement("th");
+                th.scope = "col";
+                th.textContent = column.label;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement("tbody");
+            const rowEntries = [];
+            rows.forEach((row, rowIndex) => {
+                const tr = document.createElement("tr");
+                tr.dataset.correctColumn = row.correctColumn;
+
+                const th = document.createElement("th");
+                th.scope = "row";
+                th.textContent = row.label;
+                tr.appendChild(th);
+
+                columns.forEach((column) => {
+                    const td = document.createElement("td");
+                    const label = document.createElement("label");
+                    label.className = "matching-radio";
+
+                    const input = document.createElement("input");
+                    input.type = "radio";
+                    input.name = `${slideElement.id}-row-${rowIndex + 1}`;
+                    input.value = column.id;
+
+                    const indicator = document.createElement("span");
+                    indicator.className = "matching-radio-indicator";
+
+                    label.appendChild(input);
+                    label.appendChild(indicator);
+                    td.appendChild(label);
+                    tr.appendChild(td);
+                });
+
+                tbody.appendChild(tr);
+                rowEntries.push({ row, element: tr });
+            });
+            table.appendChild(tbody);
+            tableWrapper.appendChild(table);
+            content.appendChild(tableWrapper);
+
+            const initialSummary = config.feedbackSummary || "Check your work to see detailed feedback.";
+            const feedback = createActivityFeedback(initialSummary);
+
+            const evaluate = () => {
+                let attempted = 0;
+                let correct = 0;
+                feedback.list.innerHTML = "";
+                rowEntries.forEach(({ row, element }) => {
+                    element.classList.remove("is-correct", "is-incorrect");
+                    const selected = element.querySelector("input[type=\"radio\"]:checked");
+                    if (!selected) {
+                        return;
+                    }
+                    attempted += 1;
+                    const isCorrect = selected.value === row.correctColumn;
+                    if (isCorrect) {
+                        correct += 1;
+                    }
+                    element.classList.add(isCorrect ? "is-correct" : "is-incorrect");
+
+                    const detail = document.createElement("li");
+                    detail.className = `activity-feedback__item ${isCorrect ? "is-correct" : "is-incorrect"}`;
+
+                    const heading = document.createElement("p");
+                    const strong = document.createElement("strong");
+                    strong.textContent = row.label;
+                    heading.appendChild(strong);
+                    detail.appendChild(heading);
+
+                    const yourAnswer = document.createElement("p");
+                    yourAnswer.innerHTML = `<strong>Your answer:</strong> ${columnMap.get(selected.value) || selected.value}`;
+                    detail.appendChild(yourAnswer);
+
+                    if (!isCorrect) {
+                        const correctAnswer = document.createElement("p");
+                        correctAnswer.innerHTML = `<strong>Correct answer:</strong> ${columnMap.get(row.correctColumn) || row.correctColumn}`;
+                        detail.appendChild(correctAnswer);
+                    }
+
+                    if (row.explanation) {
+                        const explanation = document.createElement("p");
+                        explanation.textContent = row.explanation;
+                        detail.appendChild(explanation);
+                    }
+
+                    feedback.list.appendChild(detail);
+                });
+
+                feedback.summary.textContent = attempted
+                    ? `You answered ${correct} of ${attempted} correctly.`
+                    : "Select an answer for at least one row to see feedback.";
+            };
+
+            const reset = () => {
+                rowEntries.forEach(({ element }) => {
+                    element.classList.remove("is-correct", "is-incorrect");
+                    element.querySelectorAll("input[type=\"radio\"]").forEach((input) => {
+                        input.checked = false;
+                    });
+                });
+                feedback.list.innerHTML = "";
+                feedback.summary.textContent = initialSummary;
+            };
+
+            const controls = createActivityControls({
+                onCheck: evaluate,
+                onReset: reset,
+                checkLabel: config.checkLabel || "Check answers",
+                resetLabel: config.resetLabel || "Reset"
+            });
+
+            content.appendChild(controls.wrapper);
+            content.appendChild(feedback.wrapper);
+
             slideElement.appendChild(content);
         }
 
@@ -3101,6 +4253,18 @@
             switch (config.type) {
                 case "hero":
                     renderHeroSlide(slideElement, config);
+                    break;
+                case "gapfill":
+                    renderGapfillSlide(slideElement, config);
+                    break;
+                case "ranking":
+                    renderRankingSlide(slideElement, config);
+                    break;
+                case "grouping":
+                    renderGroupingSlide(slideElement, config);
+                    break;
+                case "matching":
+                    renderMatchingSlide(slideElement, config);
                     break;
                 case "cards":
                     renderCardsSlide(slideElement, config);

--- a/README.md
+++ b/README.md
@@ -1,52 +1,38 @@
-# Reusing the lesson shell for new materials
+# Building lessons in Mosaic Presenter
 
-The mentoring deck is now driven entirely from the `lessonLibrary` object defined near the bottom of `mentoring.html`. Each top-level key inside `lessonLibrary` becomes a selectable template in the "Lesson template" dropdown, and the associated data is what renders the slides, slide map, and saved notes.
+The Presenter shell reads from the `lessonLibrary` object near the end of `Presenter.html`. Each top-level key inside `lessonLibrary` becomes a selectable template in the **Lesson template** dropdown, and the associated data drives the slides, slide map, and saved notes for that lesson.【F:Presenter.html†L1381-L1391】【F:Presenter.html†L1433-L1516】
 
-## 1. Add a new lesson entry
-1. Open `mentoring/mentoring.html` and locate the `lessonLibrary` constant (search for `const lessonLibrary = {`).
-2. Duplicate one of the existing lesson objects (e.g., `mentoringOrientation` or `eltLessonTemplate`) and give it a new key. The key is what the selector uses internally.
-3. Update the `id`, `label`, and `meta` fields:
-   - `id` should be unique; it is also used to namespace saved slide notes in `localStorage`.
-   - `label` is what appears in the dropdown.
-   - `meta` is optional but lets you customise the eyebrow text, descriptive line under the title, and the browser page title.【F:mentoring/mentoring.html†L1209-L1268】【F:mentoring/mentoring.html†L1739-L1767】
+## 1. Add or update a lesson entry
+1. Open `Presenter.html` and locate the `const lessonLibrary = { ... }` declaration.【F:Presenter.html†L1433-L1446】
+2. Duplicate one of the existing lesson objects (for example `mentoringOrientation`, `eltLesson`, or `questionTypesShowcase`) and give it a new key; that key is what the selector uses internally.【F:Presenter.html†L1433-L1948】
+3. Update the `id`, `label`, and optional `meta` fields:
+   - `id` must be unique and is appended to the notes storage key so each lesson keeps separate annotations.【F:Presenter.html†L1433-L1446】【F:Presenter.html†L2709-L2734】
+   - `label` is the name that appears in the dropdown control.【F:Presenter.html†L1381-L1391】【F:Presenter.html†L4355-L4378】
+   - `meta` lets you customise the eyebrow text, descriptor, and browser page title for the active lesson.【F:Presenter.html†L1437-L1443】【F:Presenter.html†L4306-L4342】
 
-## 2. Define slide map sections (optional but recommended)
-Set the `sections` array to control the headings that appear in the slide map. Each section needs a `title` and the `slideKeys` that belong to it. The keys must match the `key` property for each slide configuration you define later.【F:mentoring/mentoring.html†L1218-L1234】
+## 2. Organise slide map sections
+Populate the `sections` array to define the headings shown in the slide map. Each section requires a `title` and `slideKeys` list. Keys must match the `key` property on each slide configuration so the slide map can group entries correctly.【F:Presenter.html†L1445-L1471】【F:Presenter.html†L2735-L2814】
 
-## 3. Supply the slide configurations
-Add objects to the `slides` array in the order you want them to appear. Every slide object needs at least a unique `key` and a `type`. Supported slide types and their fields are:
+## 3. Configure slides
+Add objects to the `slides` array in the order they should appear. Every slide object needs a unique `key` and `type`. If `type` is omitted the renderer falls back to the standard content layout.【F:Presenter.html†L1472-L1939】【F:Presenter.html†L4255-L4291】
 
-### `hero`
-Use for the opening slide. Accepts `title`, `subtitle`, and an `image` object with `src` and `alt`. The optional `nav.hidePrev`, `nav.nextLabel`, and `nav.nextIcon` fields customise the navigation buttons.【F:mentoring/mentoring.html†L1235-L1252】【F:mentoring/mentoring.html†L3102-L3131】
+### Standard slide types
+- `hero`: Supports `icon`, `title`, `subtitle`, and an `image` object with `src`/`alt` attributes. Ideal for opening slides.【F:Presenter.html†L3258-L3280】【F:Presenter.html†L1472-L1501】
+- `content`: Renders paragraphs, optional imagery, and flexible lists. Provide `body`, `image`, `list`, and `listStyle` as needed.【F:Presenter.html†L3281-L3313】【F:Presenter.html†L1518-L1608】
+- `cards`: Supply a `cards` array where each item can include `icon`, `title`, and `description` to display multiple callouts.【F:Presenter.html†L3963-L4000】【F:Presenter.html†L1609-L1684】
+- `story`: Combines quotes, narrative paragraphs, and optional process/outcome callouts defined on the slide object.【F:Presenter.html†L4001-L4043】【F:Presenter.html†L1685-L1754】
+- `process`: Use for multi-step flows. Add a `steps` array with `title`, `description`, and optional `duration` for each stage.【F:Presenter.html†L4044-L4099】【F:Presenter.html†L1755-L1838】
+- `quiz`: Configure single-answer questions by providing `questions`, each with `id`, `prompt`, `options`, `answer`, and feedback strings. Buttons are wired automatically.【F:Presenter.html†L4100-L4161】【F:Presenter.html†L1502-L1547】
+- `reflection`: Creates rich text areas for planning notes. Pass a `fields` array where each field defines `id`, `label`, and optional `placeholder`. You can also override the navigation via the slide’s `nav` settings.【F:Presenter.html†L4162-L4254】【F:Presenter.html†L1839-L1939】
 
-### `content`
-Displays rich text with optional media and lists. Fields include `icon`, `title`, `subtitle`, `image`, `body` (array of paragraphs), and `list`. Lists can be a simple array of strings or an array of objects with `letter`/`text` pairs when you set `listStyle` (e.g., SMART goals).【F:mentoring/mentoring.html†L1253-L1397】【F:mentoring/mentoring.html†L2800-L2827】
+### Interactive assessment slide types
+- `gapfill`: Build a `paragraph` array that mixes text segments with gap objects. Gaps support `answer`, `options`, `placeholder`, `feedbackTitle`, and `explanation`. Optional `instructions`, `feedbackSummary`, `checkLabel`, and `resetLabel` customise the experience.【F:Presenter.html†L3314-L3463】【F:Presenter.html†L1949-L1995】
+- `ranking`: Provide an `items` array where each entry has an `id`, `label`, `correctRank`, and optional `explanation`. You can seed an `initialOrder`, override control labels, and supply custom instructions.【F:Presenter.html†L3464-L3648】【F:Presenter.html†L1996-L2042】
+- `grouping`: Define `categories` and `items`. Each item references a target category via `item.category` and can include an explanatory string. Placeholders, summaries, and button labels are configurable just like the other activities.【F:Presenter.html†L3649-L3795】【F:Presenter.html†L2043-L2132】
+- `matching`: Set up `columns` and `rows` to create a multiple-choice grid. Each row specifies `correctColumn` and optional `explanation`. Global instructions, feedback summaries, and button labels work the same way.【F:Presenter.html†L3796-L3962】【F:Presenter.html†L2133-L2219】
 
-### `cards`
-Shows multiple callouts side by side. Provide `cards`, an array of objects with optional `icon`, `title`, and `description` values.【F:mentoring/mentoring.html†L1362-L1379】【F:mentoring/mentoring.html†L2829-L2856】
+## 4. Launch your lesson
+Open `Presenter.html` in a browser and use the **Lesson template** dropdown to select your lesson. The slide deck, slide map, and notes panel refresh instantly when you change templates.【F:Presenter.html†L1381-L1391】【F:Presenter.html†L4311-L4342】
 
-### `story`
-Combines a quote, imagery, and short narrative paragraphs. The optional `process` and `outcome` objects display bold labels followed by explanatory text.【F:mentoring/mentoring.html†L1370-L1388】【F:mentoring/mentoring.html†L2858-L2896】
-
-### `process`
-Ideal for flows or procedures. Supply `steps`, an array where each item can include `title`, `description`, and `duration`. Any `image` or `body` content you add will render above the stepper.【F:mentoring/mentoring.html†L1398-L1427】【F:mentoring/mentoring.html†L2898-L2953】
-
-### `quiz`
-Renders single-answer checks for understanding. Each question needs an `id`, `prompt`, `options` (array of `{ value, label }`), an `answer`, plus feedback strings. The button wiring is automatic.【F:mentoring/mentoring.html†L1428-L1458】【F:mentoring/mentoring.html†L2955-L3023】
-
-### `reflection`
-Creates textarea fields for planning notes or reflections. Pass a `fields` array where each entry can define `id`, `label`, and `placeholder`. Navigation defaults to a "Finish & Restart" button on the last slide, but you can override it via the slide's `nav` object.【F:mentoring/mentoring.html†L1677-L1695】【F:mentoring/mentoring.html†L3025-L3073】
-
-If you omit a `type`, the slide falls back to the `content` renderer.
-
-## 4. Load your lesson in the browser
-Once your lesson object is defined:
-1. Open `mentoring/mentoring.html` in a browser.
-2. Use the "Lesson template" dropdown at the top of the page to switch to your new template. The slides, slide map, and notes panel will regenerate instantly with your data.【F:mentoring/mentoring.html†L1160-L1168】【F:mentoring/mentoring.html†L3146-L3204】
-
-Because notes are stored per lesson `id`, switching templates will keep your annotations separate for each lesson. You can export and import notes from the toolbar as before.【F:mentoring/mentoring.html†L2549-L2569】
-
-## 5. Reusing assets
-Images are linked by URL. If you need local assets, host them in the repository (e.g., under `mentoring/assets`) and point the `image.src` to the relative path. Make sure every image has meaningful alt text for accessibility.
-
-With these steps, you can duplicate the mentoring deck structure for any other instructional purpose—ELT lessons, professional learning sessions, or completely different subjects—without editing the rendering logic.
+## 5. Notes and reusable assets
+Slide notes are stored per-lesson in `localStorage` using the lesson `id`, so switching templates keeps annotations separate. Import/export controls remain available from the toolbar. Images can point to remote URLs or relative paths in the repository; be sure to include descriptive alt text for accessibility.【F:Presenter.html†L2687-L2734】【F:Presenter.html†L1455-L1939】


### PR DESCRIPTION
## Summary
- refresh the README to describe managing lessons via the Presenter.html `lessonLibrary`
- document the interactive gap-fill, ranking, grouping, and matching slide types imported from the standalone activities
- clarify slide map organisation, notes storage, and how to launch lessons in the updated presenter shell

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db216bb06c83268be032e2d9e26f51