### PR TITLE
Add dynamic Palestinian art negotiation lesson template

### DIFF
--- a/Presenter.html
+++ b/Presenter.html
@@ -1937,6 +1937,231 @@
                     }
                 ]
             },
+            palestinianArtCurators: {
+                id: "palestinian-art-curators",
+                label: "Palestinian art negotiation lesson",
+                meta: {
+                    eyebrow: "ELT Lesson Design",
+                    descriptor: "Guide learners through negotiating an exhibition of contemporary Palestinian art.",
+                    pageTitle: "Palestinian Art Negotiation – Instructional Slides"
+                },
+                sections: [
+                    { title: "Lesson Overview", slideKeys: ["palestinian-hero", "palestinian-aims", "palestinian-materials"] },
+                    { title: "Lead-in & Activation", slideKeys: ["lead-in-overview"] },
+                    { title: "Pre-task Preparation", slideKeys: ["jigsaw-setup", "jigsaw-home-groups", "negotiation-language"] },
+                    { title: "Main Task & Reporting", slideKeys: ["curators-task", "reporting-pitch"] },
+                    { title: "Reflection & Extension", slideKeys: ["gallery-walk", "exit-ticket"] },
+                    { title: "Appendices", slideKeys: ["appendix-artworks", "appendix-language", "appendix-roles"] }
+                ],
+                slides: [
+                    {
+                        key: "palestinian-hero",
+                        type: "hero",
+                        icon: "fas fa-palette",
+                        title: "Curating Palestinian Resilience",
+                        subtitle: "A negotiation-focused ELT lesson on contemporary art and cultural storytelling.",
+                        image: {
+                            src: "https://images.pexels.com/photos/11928287/pexels-photo-11928287.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+                            alt: "Visitors observing artwork in a softly lit gallery"
+                        },
+                        nav: { hidePrev: true, nextLabel: "Begin", nextIcon: "fas fa-arrow-right" }
+                    },
+                    {
+                        key: "palestinian-aims",
+                        type: "content",
+                        icon: "fas fa-bullseye",
+                        title: "Lesson aims & audience",
+                        body: [
+                            "Use this template with intermediate to advanced learners (B1–C2) over a 90–100 minute session."
+                        ],
+                        list: [
+                            { strong: "Primary aim:", text: "Students collaboratively select and justify three artworks for a themed exhibition using negotiation and consensus-building language." },
+                            { strong: "Secondary aim 1:", text: "Learners analyze and articulate the themes and messages in artworks by contemporary Palestinian artists." },
+                            { strong: "Secondary aim 2:", text: "Learners deepen their understanding of art as cultural expression and resilience." }
+                        ]
+                    },
+                    {
+                        key: "palestinian-materials",
+                        type: "content",
+                        icon: "fas fa-clipboard-list",
+                        title: "Timing & materials",
+                        body: [
+                            "Ensure the physical and digital resources below are prepped before class to keep momentum high."
+                        ],
+                        list: [
+                            { strong: "Total time:", text: "Plan for 90–100 minutes including transition moments." },
+                            { strong: "Visual support:", text: "Projector or large display plus flip chart paper and markers for gallery walk notes." },
+                            { strong: "Handouts:", text: "Appendix A (artwork descriptions), Appendix B (negotiation language), Appendix C (role cards)." },
+                            { strong: "Extras:", text: "Sticky notes for peer feedback and any optional background music for the gallery walk." }
+                        ]
+                    },
+                    {
+                        key: "lead-in-overview",
+                        type: "content",
+                        icon: "fas fa-lightbulb",
+                        title: "Lead-in: The Art of First Impressions",
+                        subtitle: "10 minutes",
+                        body: [
+                            "Prime learners by connecting personal experiences with the emotional pull of Palestinian art."
+                        ],
+                        list: [
+                            { strong: "Visual spark:", text: "Project a striking artwork (e.g., Sliman Mansour’s \"Camel of Hardships\"). Keep the title hidden." },
+                            { strong: "Think (1 minute):", text: "Silent viewing. Students note three words that come to mind." },
+                            { strong: "Pair (2–3 minutes):", text: "Learners compare words and craft a short narrative about the piece." },
+                            { strong: "Share (3–4 minutes):", text: "Elicit stories, capture emergent vocabulary, and encourage clarification questions." },
+                            { strong: "Personal connection:", text: "Invite one or two volunteers to link an artwork from their culture to its broader significance." },
+                            { strong: "Lesson launch:", text: "Frame the main task: learners will curate \"Resilience and the Land\" as part of the Al-Amal Art Collective." }
+                        ]
+                    },
+                    {
+                        key: "jigsaw-setup",
+                        type: "content",
+                        icon: "fas fa-circle-nodes",
+                        title: "Pre-task A: Expert research (10 minutes)",
+                        subtitle: "Jigsaw grouping",
+                        body: [
+                            "Use a jigsaw to guarantee accountability and even coverage across six artworks."
+                        ],
+                        list: [
+                            { strong: "Form home groups:", text: "Triads work best. Number students 1–3 before regrouping." },
+                            { strong: "Expert groups:", text: "All 1s, 2s, and 3s meet to study two assigned artworks using Appendix A." },
+                            { strong: "Research brief:", text: "Experts capture artist background, key themes and symbols, and links to Palestinian resilience." },
+                            { strong: "Facilitation tip:", text: "Provide sentence stems for summarising visual symbolism if learners need support." }
+                        ]
+                    },
+                    {
+                        key: "jigsaw-home-groups",
+                        type: "content",
+                        icon: "fas fa-people-group",
+                        title: "Pre-task A: Home group synthesis (15 minutes)",
+                        body: [
+                            "Experts return to their original trio to teach what they learned, ensuring every learner touches all six artworks."
+                        ],
+                        list: [
+                            { strong: "Teach-backs:", text: "Each expert shares highlights while peers take notes on the handout." },
+                            { strong: "Comprehension checks:", text: "Prompt listeners to ask follow-up questions using clarification language from Appendix B." },
+                            { strong: "One-sentence summaries:", text: "Groups co-create a single sentence per artwork capturing theme + cultural message." }
+                        ]
+                    },
+                    {
+                        key: "negotiation-language",
+                        type: "content",
+                        icon: "fas fa-comments",
+                        title: "Pre-task B: The Art of Persuasion",
+                        subtitle: "15 minutes",
+                        body: [
+                            "Provide space for low-stakes practice before the high-stakes curation task."
+                        ],
+                        list: [
+                            { strong: "Handout focus:", text: "Highlight negotiation stems for building on ideas and asking for clarification." },
+                            { strong: "Warm-up scenario:", text: "Groups choose one classroom print to buy with a \$500 budget. Display three contrasting options." },
+                            { strong: "Language coaching:", text: "Model a short exchange, then monitor and encourage target phrases." },
+                            { strong: "Mini-debrief:", text: "Ask which expressions supported consensus and what still felt challenging." }
+                        ]
+                    },
+                    {
+                        key: "curators-task",
+                        type: "process",
+                        icon: "fas fa-handshake",
+                        title: "Task: The Curators' Committee",
+                        subtitle: "25 minutes",
+                        body: [
+                            "Learners become the Al-Amal (Hope) Art Collective, crafting the final line-up for \"Resilience and the Land\"."
+                        ],
+                        steps: [
+                            { title: "Assign roles", description: "Distribute Appendix C so each learner adopts Curator of Artistic Merit, Curator of Thematic Storytelling, or Lead Negotiator." },
+                            { title: "Revisit criteria", description: "Project the constraints: include the land, embody resilience, and diversify styles/artists." },
+                            { title: "Negotiate selection", description: "Encourage turn-taking, paraphrasing, and consensus language while narrowing to three artworks." },
+                            { title: "Prepare the pitch", description: "Teams draft justifications highlighting narrative flow, visual impact, and community resonance." }
+                        ]
+                    },
+                    {
+                        key: "reporting-pitch",
+                        type: "content",
+                        icon: "fas fa-podium",
+                        title: "Reporting: The Exhibition Pitch",
+                        subtitle: "15 minutes",
+                        body: [
+                            "Transform reporting into a persuasive pitch with active listeners acting as the museum board."
+                        ],
+                        list: [
+                            { strong: "Lead negotiator spotlight:", text: "One speaker introduces the trio’s selections and references negotiation highlights." },
+                            { strong: "Audience role:", text: "Classmates pose one to two probing questions using challenge stems (e.g., \"Can you elaborate on…?\")." },
+                            { strong: "Feedback capture:", text: "Have note-takers log compelling phrasing or insights for later reflection." }
+                        ]
+                    },
+                    {
+                        key: "gallery-walk",
+                        type: "content",
+                        icon: "fas fa-person-walking",
+                        title: "Reflect & extend: Gallery walk",
+                        subtitle: "10 minutes",
+                        body: [
+                            "Shift energy with movement while validating each group’s curatorial work."
+                        ],
+                        list: [
+                            { strong: "Display work:", text: "Each team posts their three-piece exhibition with short rationales on flip chart paper." },
+                            { strong: "Peer interaction:", text: "Students circulate, adding sticky-note praise or questions to every exhibition." },
+                            { strong: "Whole-class debrief:", text: "Discuss patterns, surprising choices, and recurring themes of resilience and land." }
+                        ]
+                    },
+                    {
+                        key: "exit-ticket",
+                        type: "content",
+                        icon: "fas fa-ticket",
+                        title: "Exit ticket & reflection prompts",
+                        body: [
+                            "Close the loop with individual accountability and insight into learners’ takeaways."
+                        ],
+                        list: [
+                            { strong: "Prompt 1:", text: "Which artwork would you most like to see in person and why?" },
+                            { strong: "Prompt 2:", text: "What was the most challenging part of reaching consensus today?" },
+                            { strong: "Prompt 3:", text: "What new perspective on Palestinian art or resilience are you taking away?" }
+                        ]
+                    },
+                    {
+                        key: "appendix-artworks",
+                        type: "cards",
+                        icon: "fas fa-image",
+                        title: "Appendix A: Artwork handout",
+                        subtitle: "Summaries for six featured pieces",
+                        cards: [
+                            { title: "Sliman Mansour – Camel of Hardships", description: "Earth-toned depiction of a laboring camel symbolising the burdens and perseverance of Palestinians." },
+                            { title: "Naji Al-Ali – Handala", description: "Recurring child refugee figure confronting injustice and inviting viewers to witness steadfast resistance." },
+                            { title: "Ismail Shammout – Memories and Dreams", description: "Vivid diaspora scenes layering displacement, memory, and the hope of return." },
+                            { title: "Emily Jacir – Where We Come From", description: "Conceptual photography capturing requests from exiled Palestinians fulfilled on their behalf." },
+                            { title: "Taqi Spateen – Rooftop Prayers", description: "Street-art aesthetics portraying youth claiming space through color, movement, and faith." },
+                            { title: "Laila Shawa – The Hands of Fatima", description: "Silkscreen collage weaving protective hamsa imagery with political iconography and portraits of resilient women." }
+                        ]
+                    },
+                    {
+                        key: "appendix-language",
+                        type: "content",
+                        icon: "fas fa-language",
+                        title: "Appendix B: Negotiation language highlights",
+                        body: [
+                            "Keep these functional phrases visible during tasks to prompt strategic language use."
+                        ],
+                        list: [
+                            { strong: "Building on an idea:", text: "To build on what [Name] said… • That's an interesting point; it also makes me think about… • Yes, and furthermore…" },
+                            { strong: "Asking for clarification:", text: "I'm not sure I follow—could you explain that again? • What do you mean when you say…? • Can you give me an example?" },
+                            { strong: "Reaching consensus:", text: "Maybe we can combine both ideas by… • I'm happy to go with that if we also… • It sounds like we all agree that…" }
+                        ]
+                    },
+                    {
+                        key: "appendix-roles",
+                        type: "cards",
+                        icon: "fas fa-id-badge",
+                        title: "Appendix C: Role cards",
+                        subtitle: "Distribute one per learner",
+                        cards: [
+                            { title: "Curator of Artistic Merit", description: "Advocates for visual impact, technique, and stylistic diversity. Prompts peers to reference color, composition, and medium." },
+                            { title: "Curator of Thematic Storytelling", description: "Guards the narrative arc, ensuring each piece echoes resilience and the land through symbols and artist context." },
+                            { title: "Lead Negotiator", description: "Facilitates balanced participation, checks understanding, and guides the group toward consensus within the constraints." }
+                        ]
+                    }
+                ]
+            },
             questionTypesShowcase: {
                 id: "question-types-showcase",
                 label: "Interactive question types",

--- a/README.md
+++ b/README.md
@@ -34,5 +34,9 @@ Add objects to the `slides` array in the order they should appear. Every slide o
 ## 4. Launch your lesson
 Open `Presenter.html` in a browser and use the **Lesson template** dropdown to select your lesson. The slide deck, slide map, and notes panel refresh instantly when you change templates.【F:Presenter.html†L1381-L1391】【F:Presenter.html†L4311-L4342】
 
+### Example: Dynamic ELT curation task
+- Select **Palestinian art negotiation lesson** to access a full 90–100 minute sequence that guides learners through lead-in, jigsaw research, negotiation, reporting, and reflection activities while providing ready-to-print appendices.【F:Presenter.html†L1433-L1939】
+- The template uses content, process, and cards layouts to model stages such as Think-Pair-Share, expert/home group jigsaws, curated pitches, and gallery walk reflections.【F:Presenter.html†L1482-L1910】
+
 ## 5. Notes and reusable assets
 Slide notes are stored per-lesson in `localStorage` using the lesson `id`, so switching templates keeps annotations separate. Import/export controls remain available from the toolbar. Images can point to remote URLs or relative paths in the repository; be sure to include descriptive alt text for accessibility.【F:Presenter.html†L2687-L2734】【F:Presenter.html†L1455-L1939】


### PR DESCRIPTION
## Summary
- add a Palestinian art negotiation lesson template covering aims, lead-in, jigsaw expert tasks, negotiation, and reporting
- provide appendix cards for artworks, language stems, and role cards to support the main task
- document the new dynamic ELT example in the README for quick discovery

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68db2810de948326a09858ffb5614116