### PR TITLE
Add typography utilities and collapsible planner documentation

### DIFF
--- a/Presenter.html
+++ b/Presenter.html
@@ -495,12 +495,14 @@
             --font-display: 'Questrial', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
             --font-body: 'Nunito', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
 
+            --step--2: clamp(0.75rem, 0.7rem + 0.12vw, 0.84rem);
             --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 0.95rem);
             --step-0: clamp(1rem, 0.96rem + 0.22vw, 1.1rem);
             --step-1: clamp(1.125rem, 1.07rem + 0.35vw, 1.3rem);
             --step-2: clamp(1.375rem, 1.28rem + 0.55vw, 1.6rem);
             --step-3: clamp(1.75rem, 1.58rem + 0.95vw, 2.1rem);
             --step-4: clamp(2.25rem, 1.98rem + 1.35vw, 2.7rem);
+            --step-5: clamp(2.85rem, 2.4rem + 1.9vw, 3.6rem);
 
             --space-1: 0.25rem;
             --space-2: 0.5rem;
@@ -812,6 +814,41 @@
             margin: var(--space-6) 0 var(--space-3) 0;
         }
 
+        /* ------------------------------- Typography utility helpers ----------------------------------*/
+        .text-xs { font-size: var(--step--2); }
+        .text-sm { font-size: var(--step--1); }
+        .text-base { font-size: var(--step-0); }
+        .text-lg { font-size: var(--step-1); }
+        .text-xl { font-size: var(--step-2); }
+        .text-xxl { font-size: var(--step-3); }
+        .text-display { font-size: var(--step-5); letter-spacing: -0.01em; }
+        .fw-light { font-weight: 300; }
+        .fw-regular { font-weight: 400; }
+        .fw-semibold { font-weight: 600; }
+        .fw-bold { font-weight: 700; }
+        .fw-black { font-weight: 800; }
+        .text-uppercase { text-transform: uppercase; letter-spacing: 0.12em; font-weight: 700; }
+        .text-italic { font-style: italic; }
+        .text-underline { text-decoration-line: underline; text-decoration-thickness: 0.18em; text-underline-offset: 0.22em; }
+        .text-underline-sage { text-decoration-color: var(--secondary-sage); }
+        .text-underline-gold { text-decoration-color: var(--amber); }
+        .text-underline-ink { text-decoration-color: var(--ink); }
+        .text-sage { color: var(--secondary-sage); }
+        .text-fern { color: var(--fern); }
+        .text-amber { color: var(--amber); }
+        .text-ink { color: var(--ink); }
+        .text-muted { color: var(--ink-muted); }
+        .text-soft { color: color-mix(in srgb, var(--soft-white) 90%, #fff 10%); }
+        .text-shadow { text-shadow: 0 4px 18px rgba(34, 41, 32, 0.25); }
+        .text-highlight { background: linear-gradient(120deg, rgba(198, 170, 119, 0.25), rgba(156, 175, 136, 0.35)); padding: 0 0.2em; border-radius: var(--radius-sm); }
+
+        /* ------------------------------- Accent containers ----------------------------------*/
+        .accent-chip { display: inline-flex; align-items: center; gap: var(--space-2); padding: 0.3em 0.8em; border-radius: 999px; background: rgba(122, 132, 113, 0.16); font-weight: 700; font-size: var(--step--1); }
+        .accent-chip--glow { background: linear-gradient(135deg, rgba(198, 170, 119, 0.55), rgba(156, 175, 136, 0.45)); color: var(--deep-forest); box-shadow: 0 6px 16px rgba(198, 170, 119, 0.35); }
+        .accent-card { position: relative; padding: clamp(20px, 3vw, 40px); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--soft-white) 88%, rgba(198, 170, 119, 0.25) 12%); box-shadow: var(--shadow-2); overflow: hidden; }
+        .accent-card::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: radial-gradient(260px 260px at 90% 10%, rgba(198, 170, 119, 0.22), transparent 60%); }
+        .accent-card--frost { background: color-mix(in srgb, rgba(122, 132, 113, 0.12) 40%, white 60%); backdrop-filter: blur(12px); }
+
         .presentation-header {
             position: sticky;
             top: 0;
@@ -966,23 +1003,55 @@
         .presentation-menu__card .presentation-menu__hint {
             line-height: 1.5;
         }
-        .lesson-overview {
-            margin: 0 0 var(--space-6);
-            padding: var(--space-5);
+        .lesson-overview { margin: 0 0 var(--space-6); }
+        .lesson-overview[hidden] { display: none; }
+        .lesson-overview__collapsible {
             border-radius: var(--radius-lg);
-            border: 1px solid rgba(122, 132, 113, 0.14);
+            border: 1px solid rgba(122, 132, 113, 0.18);
             background: color-mix(in srgb, var(--soft-white) 92%, white 8%);
             box-shadow: var(--shadow-1);
-            display: grid;
-            gap: var(--space-4);
+            transition: box-shadow var(--dur-2) var(--ease-ambient), transform var(--dur-2) var(--ease-ambient);
+            overflow: hidden;
         }
-        .lesson-overview[hidden] {
-            display: none;
+        .lesson-overview__collapsible[open] {
+            box-shadow: var(--shadow-2);
+            transform: translateY(-2px);
+        }
+        .lesson-overview__summary {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--space-4);
+            padding: var(--space-3) var(--space-4);
+            list-style: none;
+            cursor: pointer;
+            font-size: var(--step-0);
+            font-weight: 700;
+            color: var(--forest-shadow);
+            transition: background-color var(--dur-2) var(--ease-ambient);
+        }
+        .lesson-overview__summary::-webkit-details-marker { display: none; }
+        .lesson-overview__summary::after {
+            content: "\f107";
+            font-family: "Font Awesome 6 Free";
+            font-weight: 900;
+            font-size: var(--step-1);
+            color: var(--primary-sage);
+            transition: transform var(--dur-2) var(--ease-ambient);
+        }
+        .lesson-overview__summary:hover,
+        .lesson-overview__summary:focus-visible {
+            outline: none;
+            background: rgba(156, 175, 136, 0.12);
+        }
+        .lesson-overview__collapsible[open] .lesson-overview__summary::after {
+            transform: rotate(180deg);
         }
         .lesson-overview__header {
             display: flex;
             flex-direction: column;
             gap: var(--space-2);
+            flex: 1 1 auto;
         }
         .lesson-overview__title {
             margin: 0;
@@ -993,6 +1062,7 @@
         .lesson-overview__meta {
             display: flex;
             flex-wrap: wrap;
+            align-items: center;
             gap: var(--space-2);
             font-size: var(--step--1);
             color: var(--ink-muted);
@@ -1007,6 +1077,30 @@
             color: var(--forest-shadow);
             font-weight: 700;
             font-size: var(--step--1);
+        }
+        .lesson-overview__panel {
+            padding: 0 var(--space-4) var(--space-4);
+            display: grid;
+            gap: var(--space-4);
+        }
+        .lesson-overview__subtitle {
+            margin: 0;
+            font-size: var(--step--1);
+            color: var(--ink-muted);
+        }
+        .lesson-overview__summary-hint {
+            font-size: var(--step--1);
+            font-weight: 500;
+            color: var(--ink-muted);
+            max-width: clamp(180px, 40vw, 420px);
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+        @media (max-width: 640px) {
+            .lesson-overview__summary { flex-direction: column; align-items: flex-start; }
+            .lesson-overview__summary::after { align-self: flex-end; }
+            .lesson-overview__summary-hint { white-space: normal; max-width: 100%; }
         }
         .lesson-overview__body {
             display: grid;
@@ -1318,6 +1412,35 @@
             margin-bottom: var(--space-6);
         }
         .slide-content.is-centered img { margin-left: auto; margin-right: auto; }
+        .slide-content.is-right-aligned { text-align: right; }
+        .slide-content.is-right-aligned > * { margin-left: auto; }
+        .slide-content.is-right-aligned .activity-block { text-align: left; }
+
+        .slide-content.layout--columns { display: grid; gap: clamp(var(--space-5), 4vw, var(--space-7)); }
+        @media (min-width: 768px) {
+            .slide-content.layout--columns { grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start; }
+        }
+        .slide-content.layout--columns > *:first-child { order: 0; }
+        .slide-content.layout--columns > img { height: auto; max-height: 360px; }
+
+        .slide-content.layout--poster { padding: clamp(24px, 3vw, 44px); border-radius: var(--radius-xl); background: linear-gradient(135deg, rgba(248, 246, 240, 0.85), rgba(198, 170, 119, 0.25)); box-shadow: var(--shadow-3); position: relative; overflow: hidden; }
+        .slide-content.layout--poster::before { content: ""; position: absolute; inset: -20% 40% auto -20%; height: 140%; background: radial-gradient(280px 280px at 40% 20%, rgba(156, 175, 136, 0.32), transparent 72%); pointer-events: none; }
+        .slide-content.layout--poster > * { position: relative; }
+
+        .slide-content.layout--spotlight { position: relative; padding: clamp(20px, 3vw, 36px); border-radius: var(--radius-lg); background: color-mix(in srgb, rgba(122, 132, 113, 0.16) 35%, #fff 65%); border: 1px solid rgba(122, 132, 113, 0.22); box-shadow: 0 22px 45px rgba(34, 41, 32, 0.12); }
+        .slide-content.layout--spotlight::before { content: ""; position: absolute; inset: 0; background: radial-gradient(320px 220px at 20% 0%, rgba(198, 170, 119, 0.28), transparent 75%); pointer-events: none; mix-blend-mode: multiply; }
+        .slide-content.layout--spotlight > * { position: relative; }
+
+        .slide-content.layout--timeline { display: grid; gap: var(--space-4); padding: clamp(20px, 3vw, 36px); border-left: 4px solid rgba(156, 175, 136, 0.6); }
+        .slide-content.layout--timeline > * { padding-left: var(--space-4); position: relative; }
+        .slide-content.layout--timeline > *::before { content: ""; position: absolute; left: calc(-1 * var(--space-4) - 10px); top: 0.5em; width: 12px; height: 12px; border-radius: 999px; background: var(--secondary-sage); box-shadow: 0 0 0 4px rgba(156, 175, 136, 0.2); }
+
+        .theme--sunrise { background: linear-gradient(140deg, rgba(255, 243, 226, 0.92), rgba(198, 170, 119, 0.45)); color: var(--deep-forest); border-radius: var(--radius-lg); padding: clamp(24px, 3vw, 40px); box-shadow: var(--shadow-2); }
+        .theme--sunrise :where(p, li) { color: inherit; }
+        .theme--midnight { background: linear-gradient(160deg, rgba(34, 41, 32, 0.9), rgba(34, 41, 32, 0.75)); color: var(--soft-white); border-radius: var(--radius-lg); padding: clamp(24px, 3vw, 40px); box-shadow: 0 20px 60px rgba(34, 41, 32, 0.45); }
+        .theme--midnight :where(p, li, h1, h2, h3, h4) { color: inherit; }
+        .theme--midnight .text-muted { color: color-mix(in srgb, var(--soft-white) 65%, rgba(255, 255, 255, 0.72) 35%); }
+        .theme--aurora { background: radial-gradient(220px 220px at 10% 10%, rgba(156, 175, 136, 0.4), transparent 65%), radial-gradient(220px 260px at 90% 15%, rgba(198, 170, 119, 0.36), transparent 70%), color-mix(in srgb, var(--soft-white) 92%, rgba(122, 132, 113, 0.22) 8%); border-radius: var(--radius-xl); padding: clamp(24px, 3vw, 44px); box-shadow: var(--shadow-3); }
 
         .activity-block {
             margin-top: var(--space-7);
@@ -3363,6 +3486,34 @@
             return paragraph;
         }
 
+        function applyLayoutOptions(target, layout) {
+            if (!target || !layout) {
+                return;
+            }
+            const alignment = layout.alignment || layout.align;
+            if (alignment === "center") {
+                target.classList.add("is-centered");
+            }
+            if (alignment === "end" || alignment === "right") {
+                target.classList.add("is-right-aligned");
+            }
+            const rawClassNames = Array.isArray(layout.className)
+                ? layout.className.flatMap((value) => (typeof value === "string" ? value.split(/\s+/) : []))
+                : typeof layout.className === "string"
+                ? layout.className.split(/\s+/)
+                : [];
+            rawClassNames.filter(Boolean).forEach((name) => {
+                target.classList.add(name);
+            });
+            const themes = Array.isArray(layout.theme) ? layout.theme : layout.theme ? [layout.theme] : [];
+            themes
+                .map((theme) => (typeof theme === "string" ? theme.trim() : ""))
+                .filter(Boolean)
+                .forEach((theme) => {
+                    target.classList.add(`theme--${theme}`);
+                });
+        }
+
         function createListElement(items = [], options = "bullets") {
             if (!Array.isArray(items) || !items.length) {
                 return null;
@@ -3614,12 +3765,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content";
-            if (config.layout && config.layout.alignment === "center") {
-                content.classList.add("is-centered");
-            }
-            if (config.layout && config.layout.className) {
-                content.classList.add(config.layout.className);
-            }
+            applyLayoutOptions(content, config.layout);
             if (config.image) {
                 const img = createImageElement(config.image);
                 if (img) {
@@ -3659,6 +3805,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content";
+            applyLayoutOptions(content, config.layout);
             (config.body || []).forEach((paragraph) => {
                 const paragraphElement = createParagraph(paragraph);
                 if (paragraphElement) {
@@ -3706,6 +3853,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content";
+            applyLayoutOptions(content, config.layout);
             (config.body || []).forEach((paragraph) => {
                 const paragraphElement = createParagraph(paragraph);
                 if (paragraphElement) {
@@ -3774,6 +3922,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content reporting-layout";
+            applyLayoutOptions(content, config.layout);
             (config.body || []).forEach((paragraph) => {
                 const paragraphElement = createParagraph(paragraph);
                 if (paragraphElement) {
@@ -3869,6 +4018,7 @@
 
             const content = document.createElement("div");
             content.className = "slide-content gapfill-activity";
+            applyLayoutOptions(content, config.layout);
 
             if (config.image) {
                 const img = createImageElement(config.image);
@@ -4019,6 +4169,7 @@
 
             const content = document.createElement("div");
             content.className = "slide-content ranking-activity";
+            applyLayoutOptions(content, config.layout);
 
             if (config.image) {
                 const img = createImageElement(config.image);
@@ -4204,6 +4355,7 @@
 
             const content = document.createElement("div");
             content.className = "slide-content grouping-activity";
+            applyLayoutOptions(content, config.layout);
 
             if (config.image) {
                 const img = createImageElement(config.image);
@@ -4351,6 +4503,7 @@
 
             const content = document.createElement("div");
             content.className = "slide-content matching-activity";
+            applyLayoutOptions(content, config.layout);
 
             if (config.image) {
                 const img = createImageElement(config.image);
@@ -4517,6 +4670,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content card-container";
+            applyLayoutOptions(content, config.layout);
             (config.cards || []).forEach((cardConfig) => {
                 const card = document.createElement("div");
                 card.className = "card animate-on-scroll";
@@ -4556,6 +4710,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content";
+            applyLayoutOptions(content, config.layout);
             if (config.image) {
                 const img = createImageElement(config.image);
                 if (img) {
@@ -4599,6 +4754,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content";
+            applyLayoutOptions(content, config.layout);
             if (config.image) {
                 const img = createImageElement(config.image);
                 if (img) {
@@ -4648,6 +4804,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content";
+            applyLayoutOptions(content, config.layout);
             (config.questions || []).forEach((question) => {
                 const card = document.createElement("div");
                 card.className = "quiz-card animate-on-scroll";
@@ -4716,6 +4873,7 @@
             }
             const content = document.createElement("div");
             content.className = "slide-content reflection-form";
+            applyLayoutOptions(content, config.layout);
             (config.fields || []).forEach((field, index) => {
                 const wrapper = document.createElement("div");
                 wrapper.className = "reflection-field animate-on-scroll";
@@ -4870,12 +5028,19 @@
                 return;
             }
 
-            const title = document.createElement("h2");
-            title.className = "lesson-overview__title";
-            title.textContent = planner.title || "Lesson overview";
+            const details = document.createElement("details");
+            details.className = "lesson-overview__collapsible";
+            details.setAttribute("data-collapsible", "planner");
+
+            const summary = document.createElement("summary");
+            summary.className = "lesson-overview__summary";
 
             const header = document.createElement("div");
             header.className = "lesson-overview__header";
+
+            const title = document.createElement("h2");
+            title.className = "lesson-overview__title";
+            title.textContent = planner.title || "Lesson overview";
             header.appendChild(title);
 
             if (planner.duration || planner.subtitle) {
@@ -4888,16 +5053,28 @@
                     meta.appendChild(badge);
                 }
                 if (planner.subtitle) {
-                    const subtitle = document.createElement("span");
-                    subtitle.textContent = planner.subtitle;
-                    meta.appendChild(subtitle);
+                    const hint = document.createElement("span");
+                    hint.className = "lesson-overview__summary-hint";
+                    hint.textContent = planner.subtitle;
+                    meta.appendChild(hint);
                 }
                 if (meta.childNodes.length) {
                     header.appendChild(meta);
                 }
             }
 
-            lessonOverview.appendChild(header);
+            summary.appendChild(header);
+            details.appendChild(summary);
+
+            const panel = document.createElement("div");
+            panel.className = "lesson-overview__panel";
+
+            if (planner.subtitle) {
+                const subtitleParagraph = document.createElement("p");
+                subtitleParagraph.className = "lesson-overview__subtitle";
+                subtitleParagraph.textContent = planner.subtitle;
+                panel.appendChild(subtitleParagraph);
+            }
 
             const body = document.createElement("div");
             body.className = "lesson-overview__body";
@@ -4977,13 +5154,19 @@
                 calloutLabel.textContent = "Facilitation spotlight:";
                 callout.appendChild(calloutLabel);
                 callout.appendChild(document.createTextNode(` ${planner.spotlight}`));
-                body.appendChild(callout);
+                panel.appendChild(callout);
             }
 
             if (body.childNodes.length) {
-                lessonOverview.appendChild(body);
+                panel.appendChild(body);
             }
 
+            if (panel.childNodes.length) {
+                details.appendChild(panel);
+            }
+
+            details.open = false;
+            lessonOverview.appendChild(details);
             lessonOverview.hidden = false;
             lessonOverview.setAttribute("aria-hidden", "false");
         }

--- a/README.md
+++ b/README.md
@@ -1,38 +1,97 @@
 # Building lessons in Mosaic Presenter
 
-The Presenter shell reads from the `lessonLibrary` object near the end of `Presenter.html`. Each top-level key inside `lessonLibrary` becomes a selectable template in the **Lesson template** dropdown, and the associated data drives the slides, slide map, and saved notes for that lesson.【F:Presenter.html†L1381-L1391】【F:Presenter.html†L1433-L1516】
+The Presenter shell reads from the `lessonLibrary` object near the end of `Presenter.html`. Each top-level key becomes a selectable template in the **Lesson template** dropdown, and the associated data drives the slides, the slide map, and the saved notes for that lesson.
 
-## 1. Add or update a lesson entry
-1. Open `Presenter.html` and locate the `const lessonLibrary = { ... }` declaration.【F:Presenter.html†L1433-L1446】
-2. Duplicate one of the existing lesson objects (for example `mentoringOrientation`, `eltLesson`, or `questionTypesShowcase`) and give it a new key; that key is what the selector uses internally.【F:Presenter.html†L1433-L1948】
-3. Update the `id`, `label`, and optional `meta` fields:
-   - `id` must be unique and is appended to the notes storage key so each lesson keeps separate annotations.【F:Presenter.html†L1433-L1446】【F:Presenter.html†L2709-L2734】
-   - `label` is the name that appears in the dropdown control.【F:Presenter.html†L1381-L1391】【F:Presenter.html†L4355-L4378】
-   - `meta` lets you customise the eyebrow text, descriptor, and browser page title for the active lesson.【F:Presenter.html†L1437-L1443】【F:Presenter.html†L4306-L4342】
+## 1. Lesson templates and metadata
+1. Open `Presenter.html` and locate `const lessonLibrary = { ... }`.
+2. Duplicate one of the existing lesson objects (for example `digitalSelfDefense`, `eltLesson`, or `questionTypesShowcase`) and give it a new key; the key is what the selector uses internally.
+3. Update the top-level fields inside your lesson object:
+   - `id` must be unique and is appended to the notes storage key so each lesson keeps separate annotations.
+   - `label` is the name that appears in the dropdown control.
+   - `meta` contains presentation chrome such as the eyebrow, descriptor, browser page title, and the optional workshop planner described below.
 
-## 2. Organise slide map sections
-Populate the `sections` array to define the headings shown in the slide map. Each section requires a `title` and `slideKeys` list. Keys must match the `key` property on each slide configuration so the slide map can group entries correctly.【F:Presenter.html†L1445-L1471】【F:Presenter.html†L2735-L2814】
+### Workshop planner (collapsible overview)
+Provide a `meta.planner` object if you want a facilitator-friendly workshop plan. The planner is rendered inside a collapsible menu that stays closed on load, showing only the title, duration badge, and a truncated subtitle. When expanded it reveals the full session overview, pacing, sections, and spotlight guidance.
 
-## 3. Configure slides
-Add objects to the `slides` array in the order they should appear. Every slide object needs a unique `key` and `type`. If `type` is omitted the renderer falls back to the standard content layout.【F:Presenter.html†L1472-L1939】【F:Presenter.html†L4255-L4291】
+The planner supports the following keys:
+- `title`, `subtitle`, and `duration` describe the session headline.
+- `pacingTitle` labels the pacing list shown when the menu opens.
+- `pacing` is an array of objects with `label` and optional `duration` for each segment.
+- `sections` is an array where each entry defines a `title` and either an `items` list or a `description` paragraph.
+- `spotlight` surfaces one facilitation reminder as a callout at the bottom of the plan.
 
-### Standard slide types
-- `hero`: Supports `icon`, `title`, `subtitle`, and an `image` object with `src`/`alt` attributes. Ideal for opening slides.【F:Presenter.html†L3258-L3280】【F:Presenter.html†L1472-L1501】
-- `content`: Renders paragraphs, optional imagery, and flexible lists. Provide `body`, `image`, `list`, and `listStyle` as needed.【F:Presenter.html†L3281-L3313】【F:Presenter.html†L1518-L1608】
-- `cards`: Supply a `cards` array where each item can include `icon`, `title`, and `description` to display multiple callouts.【F:Presenter.html†L3963-L4000】【F:Presenter.html†L1609-L1684】
-- `story`: Combines quotes, narrative paragraphs, and optional process/outcome callouts defined on the slide object.【F:Presenter.html†L4001-L4043】【F:Presenter.html†L1685-L1754】
-- `process`: Use for multi-step flows. Add a `steps` array with `title`, `description`, and optional `duration` for each stage.【F:Presenter.html†L4044-L4099】【F:Presenter.html†L1755-L1838】
-- `quiz`: Configure single-answer questions by providing `questions`, each with `id`, `prompt`, `options`, `answer`, and feedback strings. Buttons are wired automatically.【F:Presenter.html†L4100-L4161】【F:Presenter.html†L1502-L1547】
-- `reflection`: Creates rich text areas for planning notes. Pass a `fields` array where each field defines `id`, `label`, and optional `placeholder`. You can also override the navigation via the slide’s `nav` settings.【F:Presenter.html†L4162-L4254】【F:Presenter.html†L1839-L1939】
+## 2. Slide map and navigation
+The `sections` array in each lesson controls the slide map on the left. Every section needs a `title` and a `slideKeys` array. Keys must match the `key` property on slide configurations so the map can group entries correctly.
 
-### Interactive assessment slide types
-- `gapfill`: Build a `paragraph` array that mixes text segments with gap objects. Gaps support `answer`, `options`, `placeholder`, `feedbackTitle`, and `explanation`. Optional `instructions`, `feedbackSummary`, `checkLabel`, and `resetLabel` customise the experience.【F:Presenter.html†L3314-L3463】【F:Presenter.html†L1949-L1995】
-- `ranking`: Provide an `items` array where each entry has an `id`, `label`, `correctRank`, and optional `explanation`. You can seed an `initialOrder`, override control labels, and supply custom instructions.【F:Presenter.html†L3464-L3648】【F:Presenter.html†L1996-L2042】
-- `grouping`: Define `categories` and `items`. Each item references a target category via `item.category` and can include an explanatory string. Placeholders, summaries, and button labels are configurable just like the other activities.【F:Presenter.html†L3649-L3795】【F:Presenter.html†L2043-L2132】
-- `matching`: Set up `columns` and `rows` to create a multiple-choice grid. Each row specifies `correctColumn` and optional `explanation`. Global instructions, feedback summaries, and button labels work the same way.【F:Presenter.html†L3796-L3962】【F:Presenter.html†L2133-L2219】
+Each slide can optionally include a `nav` object to customise on-slide navigation controls. Supported keys include `hidePrev`, `hideNext`, `prevLabel`, `prevIcon`, `nextLabel`, `nextIcon`, `nextVariant` (primary or secondary styling), and `nextAction` (for example `restart` to loop back to the first slide).
 
-## 4. Launch your lesson
-Open `Presenter.html` in a browser and use the **Lesson template** dropdown to select your lesson. The slide deck, slide map, and notes panel refresh instantly when you change templates.【F:Presenter.html†L1381-L1391】【F:Presenter.html†L4311-L4342】
+## 3. Slide configuration essentials
+Add objects to the `slides` array in the order they should appear. Every slide object needs a unique `key` and `type`. If `type` is omitted the renderer falls back to the standard content layout.
 
-## 5. Notes and reusable assets
-Slide notes are stored per-lesson in `localStorage` using the lesson `id`, so switching templates keeps annotations separate. Import/export controls remain available from the toolbar. Images can point to remote URLs or relative paths in the repository; be sure to include descriptive alt text for accessibility.【F:Presenter.html†L2687-L2734】【F:Presenter.html†L1455-L1939】
+Common properties that work across slide types:
+- `layout` lets you change alignment, add layout classes, or apply presentation themes (see Section 5).
+- `image` accepts `{ src, alt }` and is automatically wrapped in the slide’s animation hooks.
+- `body` is an array of paragraphs. You can pass strings or objects with `html` to inject rich markup (for example, `<span class="text-underline text-underline-sage">`...).
+- `list` accepts either a simple array of strings or an array of objects with `icon`, `strong`, and `text` fragments.
+- `activity` attaches a call-to-action block. Provide `title`, `description` paragraphs, optional ordered or unordered `steps`, text `inputs`, and multiple-choice `options`.
+
+## 4. Slide type reference
+### Content-driven layouts
+- `hero`: Opening splash with optional icon, title, subtitle, and hero image.
+- `content`: General-purpose slide supporting copy, imagery, lists, and embedded activity blocks.
+- `grid`: Displays reference columns defined in a `grid` array.
+- `gallery`: Renders a grid of rich cards from `items`, each with image, title, metadata, and description.
+- `reporting`: Provides a recap layout with sections for statements, data tables, or debrief prompts.
+- `cards`: Shows up to four callout cards with icons, headings, and descriptions.
+- `story`: Combines a quote-style rubric, narrative paragraphs, optional imagery, and process/outcome callouts.
+- `process`: Visualises multi-step flows from a `steps` array.
+
+### Interactive assessments and reflections
+- `gapfill`: Build a `paragraph` array mixing text segments with gap objects (`answer`, optional `options`, and `feedback`).
+- `ranking`: Provide an `items` array with `id`, `label`, and an optional `explanation` to rank actions.
+- `grouping`: Define `categories` and `items`; each item references the correct category and can include explanatory text.
+- `matching`: Configure `columns` and `rows`; each row specifies `correctColumn` and optional `explanation`.
+- `quiz`: Configure single-answer questions with `questions`, each containing `options`, the correct `answer`, and feedback strings.
+- `reflection`: Supply a `fields` array where each field defines `id`, `label`, and optional `placeholder` to collect open responses.
+
+## 5. Layout, theming, and typography utilities
+Every slide honours the `layout` object, which supports:
+- `alignment`: `"center"` or `"right"` to reflow content.
+- `className`: a string or array of class names applied to the slide container.
+- `theme`: a string or array that prefixes classes with `theme--` (for example `"sunrise"`).
+
+Available layout helper classes:
+- `layout--columns`: Two-column responsive grid for pairing copy with imagery or callouts.
+- `layout--poster`: Framed poster effect with soft gradients and elevated shadows.
+- `layout--spotlight`: Frosted, spotlighted panel suited for key ideas or case studies.
+- `layout--timeline`: Left-rail timeline with nodes for each paragraph or list item.
+
+Theme surfaces you can mix in via `layout.theme` or `className`:
+- `theme--sunrise`: Warm gradient background with dark green typography.
+- `theme--midnight`: High-contrast twilight surface with light type and softened accents.
+- `theme--aurora`: Layered radial washes for atmospheric storytelling blocks.
+
+Accent components for highlighting content:
+- `accent-chip` and `accent-chip--glow`: Compact pills for metadata or status tags.
+- `accent-card` and `accent-card--frost`: Elevated panels with radial light washes.
+- `text-highlight`: Inline gradient marker useful inside paragraph HTML snippets.
+
+Typography utility classes (combine freely inside `body` HTML, list fragments, or reflection prompts):
+- Size: `text-xs`, `text-sm`, `text-base`, `text-lg`, `text-xl`, `text-xxl`, `text-display`.
+- Weight: `fw-light`, `fw-regular`, `fw-semibold`, `fw-bold`, `fw-black`.
+- Decoration: `text-underline`, `text-underline-sage`, `text-underline-gold`, `text-underline-ink`, `text-uppercase`, `text-italic`, `text-shadow`.
+- Colour: `text-sage`, `text-fern`, `text-amber`, `text-ink`, `text-muted`, `text-soft`.
+
+These utilities enable rich textual contrasts (bold, underline, coloured, large/small) without editing the core styles.
+
+## 6. Interaction scaffolds and micro-interactions
+- All structural elements receive the `animate-on-scroll` class, triggering subtle entry animations as the slide becomes visible.
+- Activity helpers provide built-in controls: `createActivityBlock` renders headings, instructional paragraphs, optional step lists, free-response inputs, and multiple-choice groups; `createActivityControls` attaches “Check” and “Reset” buttons; `createActivityFeedback` manages per-item guidance.
+- Assessment slides expose dedicated evaluators for ranking, grouping, matching, and quiz logic so you only supply data, not algorithms.
+- A highlight toolbar, annotation composer, and popover components underpin the in-slide annotation features.
+
+## 7. Launch, notes, and reusable assets
+- Open `Presenter.html` in a browser and use the **Lesson template** dropdown to load your lesson; the slide deck, slide map, and notes panel refresh instantly when you switch templates.
+- Lesson notes are stored per `id` in `localStorage`, ensuring annotations remain isolated between templates. Import/export buttons in the notes toolbar support backup or sharing.
+- Imagery can point to remote URLs or repository-relative paths—be sure to provide descriptive `alt` text for accessibility.
+- The workshop planner menu can be expanded at any time to review pacing and facilitator moves without leaving the slide flow.


### PR DESCRIPTION
## Summary
- add new typography utilities, accent components, and themed layout surfaces to the presenter shell
- render the workshop planner inside a collapsed details menu and apply layout helpers across slide types
- refresh the README with granular guidance on planners, layout options, text styling, and interactive affordances

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbcdba52bc8326bfe92682e1dc5eb8